### PR TITLE
Add support for different PDF writers

### DIFF
--- a/gs100/converter.py
+++ b/gs100/converter.py
@@ -95,11 +95,6 @@ def cell_has_tags(cell) -> bool:
             and all(tag in cell.metadata.tags for tag in TAGS))
 
 
-def remove_input(cell) -> nbformat.NotebookNode:
-    cell.source = 'output:'
-    return cell
-
-
 def read_nb(filename) -> nbformat.NotebookNode:
     """
     Takes in a filename of a notebook and returns a notebook object containing
@@ -108,8 +103,7 @@ def read_nb(filename) -> nbformat.NotebookNode:
     with open(filename, 'r') as f:
         nb = nbformat.read(f, as_version=4)
 
-    cells = [remove_input(cell) for cell in nb['cells']
-             if cell_has_tags(cell)]
+    cells = [cell for cell in nb['cells'] if cell_has_tags(cell)]
 
     nb['cells'] = cells
     return nb


### PR DESCRIPTION
The current implementation uses PDFKit which requires wkhtmltopdf and a lot of additional dependencies that can't be pulled in with pip. WeasyPrint generates good results without requiring external packages.

Needs some testing as I've only used it as a standalone script. For homework 5, it generates a 6-page PDF instead of the 7 pages required by the Gradescope template, so we'll need to look into this as well.